### PR TITLE
Implement seed planting functionality for yearly plan

### DIFF
--- a/src/scripts/tractor.js
+++ b/src/scripts/tractor.js
@@ -1,0 +1,48 @@
+import { yearlyPlan } from "./main.js"; 
+import { createAsparagus } from "./seeds/asparagus.js";
+import { createCorn } from "./seeds/corn.js";
+import { createPotato } from "./seeds/potato.js";
+import { createSoybean } from "./seeds/soybean.js";
+import { createSunflower } from "./seeds/sunflower.js";
+import { createWheat } from "./seeds/wheat.js";
+import { addPlant } from "./field.js";
+
+/**
+ * Plants seeds in the field according to the provided ${yearlyPlan}.
+ * 
+ * @param {Array<Array<string>>} yearlyPlan - A 2D array representing the year's planting plan.
+ * Each inner array represents a ${row} in the field, and each string in the inner array
+ * represents the type of crop to be planted at that location. The ${row} parameter in
+ * the inner loop refers to each of these inner arrays, allowing us to iterate over
+ * each crop type in the ${yearlyPlan}.
+ */
+const plantSeeds = (yearlyPlan) => {
+  yearlyPlan.forEach((row) => {
+    row.forEach((cropType) => {
+      switch (cropType) {
+        case "Asparagus":
+          addPlant(createAsparagus());
+          break;
+        case "Corn":
+          createCorn().forEach((seed) => addPlant(seed));
+          break;
+        case "Potato":
+          addPlant(createPotato());
+          break;
+        case "Soybean":
+          addPlant(createSoybean());
+          break;
+        case "Sunflower":
+          addPlant(createSunflower());
+          break;
+        case "Wheat":
+          addPlant(createWheat());
+          break;
+        default:
+          console.log(`Unknown crop type: ${cropType}`);
+      }
+    });
+  });
+}
+
+plantSeeds(yearlyPlan);


### PR DESCRIPTION
## Title: Implement seed planting functionality for yearly plan
## Description:
This pull request implements the plantSeeds function, which populates the field with seeds based on the yearly plan. The function uses a switch statement to determine which type of seed to plant, and then adds the seed to the field using the addPlant function.
## Changes:

    Implemented plantSeeds function to populate field with seeds from yearly plan
    Updated plantSeeds function to use addPlant function to add seeds to field
    Added logic to handle different types of seeds (e.g. Asparagus, Corn, Potato, etc.)